### PR TITLE
Fix pyreadline3 compatibility on Windows for Python >= 3.13

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -117,7 +117,7 @@ setup(
         'python-daemon',
         'pyyaml',
         'obd',
-        "pyreadline3 ; platform_system=='Windows'"
+        "pyreadline3;platform_system=='Windows' and python_version<'3.13'",
     ],
     python_requires='>3.5'
 )


### PR DESCRIPTION
## Summary

This PR updates the compatibility condition for the pyreadline3 package to correctly handle installations on Windows with Python versions above 3.13.

## Changes

- Refine Version Marker for pyreadline3 on Windows with Python >= 3.13

## Additional Note

- With the release of Python 3.13, the [readline.backend](https://docs.python.org/fr/3/library/readline.html#readline.backend) is now part of the standard library
- [Environment Markers reference](https://packaging.python.org/en/latest/specifications/dependency-specifiers/#environment-markers)

## Related Issue

- Fixes #50 